### PR TITLE
M4: 운영·관측 마감 + PMF 트래킹 활성화

### DIFF
--- a/apps/web/actions/signup.ts
+++ b/apps/web/actions/signup.ts
@@ -94,20 +94,24 @@ export async function submitSignup(
     };
   }
 
-  // funnel telemetry — best effort, 실패해도 사용자에게 노출하지 않음
-  try {
-    const visitorId = await getOrCreateVisitorId();
-    await supabase.from("page_events").insert({
-      event_type: "form_submit_success",
-      visitor_id: visitorId,
-      utm_source: data.utm?.source ?? null,
-      utm_medium: data.utm?.medium ?? null,
-      utm_campaign: data.utm?.campaign ?? null,
-      utm_content: data.utm?.content ?? null,
-      device_type: deviceType,
-    });
-  } catch (err) {
-    console.warn("[signup] funnel event log failed", err);
+  // funnel telemetry — best effort, 실패해도 사용자에게 노출하지 않음.
+  // RFC 6761 .test TLD(예: e2e+{uuid}@trendmaplp.test)는 테스트 전용이므로
+  // PMF 분석에서 제외해 v_funnel_daily.signups_count에 노이즈가 안 섞이도록 함.
+  if (!data.email.endsWith(".test")) {
+    try {
+      const visitorId = await getOrCreateVisitorId();
+      await supabase.from("page_events").insert({
+        event_type: "form_submit_success",
+        visitor_id: visitorId,
+        utm_source: data.utm?.source ?? null,
+        utm_medium: data.utm?.medium ?? null,
+        utm_campaign: data.utm?.campaign ?? null,
+        utm_content: data.utm?.content ?? null,
+        device_type: deviceType,
+      });
+    } catch (err) {
+      console.warn("[signup] funnel event log failed", err);
+    }
   }
 
   return { ok: true };

--- a/apps/web/app/api/event/route.ts
+++ b/apps/web/app/api/event/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { eventInputSchema } from "@trendmaplp/validation";
 import { getSupabaseAdmin } from "@/lib/supabase-server";
+import {
+  detectDeviceType,
+  getOrCreateVisitorId,
+  getRequestContext,
+} from "@/lib/track";
 
 export const runtime = "nodejs";
 
@@ -9,7 +14,10 @@ export async function POST(req: Request) {
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ ok: false, code: "invalid_json" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, code: "invalid_json" },
+      { status: 400 },
+    );
   }
 
   const parsed = eventInputSchema.safeParse(body);
@@ -21,22 +29,35 @@ export async function POST(req: Request) {
   }
   const data = parsed.data;
 
+  // 클라이언트는 visitorId를 보내지 않는다. 서버가 httpOnly cookie로 결정.
+  const visitorId = data.visitorId ?? (await getOrCreateVisitorId());
+
+  // deviceType도 클라가 보내지 않으면 서버 UA로 보강.
+  let deviceType = data.deviceType;
+  if (!deviceType) {
+    const ctx = await getRequestContext();
+    deviceType = detectDeviceType(ctx.userAgent);
+  }
+
   const supabase = getSupabaseAdmin();
   const { error } = await supabase.from("page_events").insert({
     event_type: data.eventType,
-    visitor_id: data.visitorId,
+    visitor_id: visitorId,
     session_id: data.sessionId ?? null,
     referrer: data.referrer ?? null,
     utm_source: data.utm?.source ?? null,
     utm_medium: data.utm?.medium ?? null,
     utm_campaign: data.utm?.campaign ?? null,
     utm_content: data.utm?.content ?? null,
-    device_type: data.deviceType ?? null,
+    device_type: deviceType ?? null,
   });
 
   if (error) {
     console.error("[/api/event] insert failed", error);
-    return NextResponse.json({ ok: false, code: "server_error" }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, code: "server_error" },
+      { status: 500 },
+    );
   }
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { PageViewTracker } from "@/components/PageViewTracker";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -57,6 +58,7 @@ export default function RootLayout({
     >
       <body className="min-h-screen">
         {children}
+        <PageViewTracker />
         <Analytics />
       </body>
     </html>

--- a/apps/web/components/PageViewTracker.tsx
+++ b/apps/web/components/PageViewTracker.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/track-client";
+
+export function PageViewTracker() {
+  useEffect(() => {
+    trackEvent("page_view");
+  }, []);
+  return null;
+}

--- a/apps/web/components/sections/Hero.tsx
+++ b/apps/web/components/sections/Hero.tsx
@@ -1,4 +1,5 @@
 import { WordsCycler } from "./WordsCycler";
+import { HeroCTA } from "./HeroCTA";
 
 export function Hero() {
   return (
@@ -25,12 +26,7 @@ export function Hero() {
         <br />
         위치와 실제 후기를 한 번에 확인하세요.
       </p>
-      <a
-        href="#signup"
-        className="inline-flex w-full items-center justify-center py-4 bg-zinc-900 text-white rounded-2xl font-bold text-[15px] hover:bg-zinc-800 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900"
-      >
-        사전 알림 신청하기
-      </a>
+      <HeroCTA />
     </header>
   );
 }

--- a/apps/web/components/sections/HeroCTA.tsx
+++ b/apps/web/components/sections/HeroCTA.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { trackEvent } from "@/lib/track-client";
+
+export function HeroCTA() {
+  return (
+    <a
+      href="#signup"
+      onClick={() => trackEvent("cta_click")}
+      className="inline-flex w-full items-center justify-center py-4 bg-zinc-900 text-white rounded-2xl font-bold text-[15px] hover:bg-zinc-800 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-900"
+    >
+      사전 알림 신청하기
+    </a>
+  );
+}

--- a/apps/web/lib/track-client.ts
+++ b/apps/web/lib/track-client.ts
@@ -1,0 +1,52 @@
+// 클라이언트 전용 PMF 트래킹 헬퍼.
+// 자동화(Playwright/Selenium 등)는 navigator.webdriver/UA로 감지해 즉시 skip → page_events에 노이즈가 섞이지 않음.
+// fire-and-forget: 실패는 무시(PMF 측정은 보조 신호이며 사용자 경험에 영향 X).
+
+const BOT_UA_RE = /HeadlessChrome|PhantomJS|Selenium|webdriver/i;
+
+function isAutomation(): boolean {
+  if (typeof navigator === "undefined") return false;
+  if (navigator.webdriver) return true;
+  if (BOT_UA_RE.test(navigator.userAgent)) return true;
+  return false;
+}
+
+function readUtm() {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    const utm = {
+      source: sp.get("utm_source") ?? undefined,
+      medium: sp.get("utm_medium") ?? undefined,
+      campaign: sp.get("utm_campaign") ?? undefined,
+      content: sp.get("utm_content") ?? undefined,
+    };
+    return utm.source || utm.medium || utm.campaign || utm.content
+      ? utm
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export type TrackableEvent = "page_view" | "cta_click";
+
+export function trackEvent(eventType: TrackableEvent): void {
+  if (typeof window === "undefined") return;
+  if (isAutomation()) return;
+
+  const body = JSON.stringify({
+    eventType,
+    referrer: document.referrer || undefined,
+    utm: readUtm(),
+  });
+
+  void fetch("/api/event", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // PMF 측정은 보조 — 네트워크 실패해도 사용자에게 노출하지 않음
+  });
+}

--- a/docs/queries/weekly_pmf.sql
+++ b/docs/queries/weekly_pmf.sql
@@ -1,0 +1,19 @@
+-- 주간 PMF funnel · conversion%
+--
+-- 실행: 매주 월요일 Supabase Studio → SQL editor에 붙여넣고 Run.
+-- 결과를 PR 코멘트나 메모 도구에 캡처해 추세를 추적한다.
+-- 자세한 점검 절차는 `docs/runbook.md` §7 참조.
+
+select
+  to_char(day at time zone 'Asia/Seoul', 'YYYY-MM-DD') as day,
+  views,
+  unique_visitors,
+  cta_clicks,
+  signups_count,
+  case
+    when unique_visitors > 0
+      then round(100.0 * signups_count / unique_visitors, 2)
+  end as conversion_pct
+from public.v_funnel_daily
+where day >= (now() at time zone 'Asia/Seoul')::date - interval '6 days'
+order by day desc;

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -74,6 +74,7 @@ Vercel Project → **Settings → Environment Variables**에서 다음 키를 **
 3. Vercel에서 **Redeploy**(production만으로 충분).
 4. (퍼블릭 저장소 사고면) `git log`/PR diff에서 노출 시점 확인 후 `git filter-repo` 등으로 히스토리 정리는 보통 무효 — **키 회전이 1순위**.
 5. Turnstile/Upstash도 동일 절차.
+6. **Vercel 로그**: hobby 플랜은 retention 1일이라 사고 직후 즉시 캡처(스크린샷 또는 로그 export)해두는 게 안전. Pro 플랜이면 retention이 길어지지만 PMF 검증 단계엔 hobby로 충분.
 
 ## 5. 마이그레이션 절차 (M1까지 수동)
 
@@ -110,6 +111,64 @@ Playwright E2E 스위트는 실제 Supabase에 INSERT하고 service role로 clea
 
 테스트 데이터는 `e2e+{uuid}@trendmaplp.test` 패턴이라 운영 신청자 row와 충돌하지 않는다.
 
-## 7. on-call
+## 7. on-call (1인 운영)
 
-- 1인 운영. 알림 채널은 M4에서 결정 (Sentry → Discord/Telegram webhook 후보).
+알림 채널은 미도입 — Vercel 로그를 주기적으로 직접 점검한다. 사고 검출이 늦은 게 비용이 되면 Sentry 도입을 후속 이슈에서 결정.
+
+### 7.1 주간 점검 (월요일 30분)
+
+1. **Vercel 로그**: Dashboard → 프로젝트 → Logs → 최근 24h `error` 필터.
+   - 5xx, Server Action 실패, `/api/event` insert 실패, `/api/signup` 관련 에러를 체크.
+   - `[signup] insert failed`, `[/api/event] insert failed`, `[turnstile]`, `[rate-limit]` 키워드 grep으로 빠르게 훑는다.
+   - 에러 0건이면 OK. 1건 이상이면 메시지·context·발생 시각을 메모하고 §7.3로.
+2. **주간 PMF SQL** 실행: `docs/queries/weekly_pmf.sql`을 Supabase Studio SQL editor에 붙여넣고 Run.
+   - 결과 캡처 → 본인 메모 도구(Notion/notepad)에 일자별로 누적.
+   - `conversion_pct` 추세를 확인. 광고 시작 후 D+7부터 의미 있는 신호.
+3. **신청자 신규 카운트**:
+   ```sql
+   select count(*) from public.signups where created_at > now() - interval '7 days';
+   ```
+4. **PII row 정합성**:
+   ```sql
+   select count(*) from public.signups where email is null or email = '';
+   ```
+   결과 0이어야 함.
+
+### 7.2 사고 분류
+
+| 증상 | 1차 조치 |
+|---|---|
+| Vercel 로그에서 `[signup] insert failed` 반복 | Supabase 키 만료/회전 의심 → §4 시크릿 회전 |
+| 신청은 가능하나 page_events 카운트 0 | `/api/event` route 에러 확인. 클라이언트 fetch 실패는 봇 가드 또는 rate-limit |
+| 시크릿 누설 의심(GitHub commit/log) | **즉시** §4 시크릿 회전. 그 다음 누설 범위 추적 |
+| 잘못된 배포 | §6 롤백 → 원인 fix PR |
+| DB 정합성 문제 | 새 마이그레이션 PR (§5) — 직접 `update`/`delete`는 가능한 피하고 SQL 파일로 흔적 남기기 |
+
+### 7.3 사고 기록
+
+- 사고 발생 시 `docs/incidents/YYYY-MM-DD-요약.md`로 5W1H 짧게 정리(미래 운영자/본인용).
+- 1주 이상 영향이 있으면 GitHub Issue로도 트래킹.
+
+## 8. 신청자 데이터 export
+
+마케팅 메일 송신, 사전 알림 발송, 분석 등 PII를 다룰 때.
+
+### 8.1 Supabase Studio UI
+1. Table editor → `signups` → 우상단 **Export to CSV**.
+2. 다운로드된 CSV는 신뢰 가능한 위치(Mac 기본 Downloads → 비밀번호 보관소)에 저장.
+3. 외부 공유 시 PII 처리방침에 동의 받은 컬럼만 포함.
+
+### 8.2 SQL로 컬럼 선택 export (권장)
+민감 정보는 줄여서 export — 필요한 컬럼만:
+```sql
+select email, source, utm_medium, utm_campaign, utm_content,
+       device_type, created_at
+from public.signups
+order by created_at;
+```
+SQL editor 결과창의 **Download** 버튼으로 CSV 저장.
+
+### 8.3 보관·삭제 원칙
+- export 파일은 사용 직후 **삭제** 또는 암호화된 보관소(1Password Vault 등)로 이동.
+- 외부 메일 서비스(Resend 등)에 업로드 후 7일 이내 원본 삭제.
+- 사용자 신청 취소(이메일 수신 거부) 요청 시 `delete from signups where email = '...'` 후 export 파일에서도 해당 행 제거.

--- a/packages/validation/src/event.ts
+++ b/packages/validation/src/event.ts
@@ -11,7 +11,8 @@ export type EventType = z.infer<typeof eventTypeSchema>;
 
 export const eventInputSchema = z.object({
   eventType: eventTypeSchema,
-  visitorId: z.string().min(8).max(64),
+  // 미전송 시 서버(/api/event)가 cookie 기반으로 발급/조회하여 채움.
+  visitorId: z.string().min(8).max(64).optional(),
   sessionId: z.string().min(8).max(64).optional(),
   referrer: z.string().max(500).optional(),
   utm: utmSchema.optional(),


### PR DESCRIPTION
## 요약
- 클라이언트에서 \`page_view\`·\`cta_click\` 이벤트를 \`/api/event\`로 전송 → \`v_funnel_daily\` 뷰가 비로소 의미 있는 수치를 보유. 이 작업 전엔 두 컬럼이 항상 0이라 주간 SQL이 구조적으로 무의미했음
- visitor_id는 기존 httpOnly cookie 경로 그대로 유지 — 클라이언트는 visitorId를 보내지 않고 route handler가 \`getOrCreateVisitorId()\`로 채움. XSS 방지력 보존
- 봇·자동화 가드: \`navigator.webdriver\` + \`HeadlessChrome|PhantomJS|Selenium|webdriver\` UA 정규식 → 즉시 skip. signup Server Action의 funnel telemetry는 \`.test\` TLD 이메일 스킵 → e2e+{uuid}@trendmaplp.test 트래픽이 \`v_funnel_daily.signups_count\`에 안 섞임
- 주간 PMF SQL을 \`docs/queries/weekly_pmf.sql\`에 커밋 — 매주 월요일 Supabase Studio에서 1번 실행
- \`docs/runbook.md\` §4/§7/§8 보강
  - §4: Vercel 로그 retention 1일 메모(사고 직후 즉시 캡처)
  - §7: 비어있던 stub을 "1인 운영자 주간 점검 30분 + 사고 분류 + 사고 기록" 절차로 채움
  - §8: 신청자 CSV export(Studio UI / SQL) + 보관·삭제 원칙 신규
- 에러 추적은 **Vercel 로그만** 도입(Sentry는 후속 이슈) — PMF 단계 비용·노력 최소화

## 검증
### 자동
- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm build\` ✅ — \`/\`는 정적(○) prerender 유지
- \`pnpm --filter @trendmaplp/web test:e2e\` ✅ — chromium + 모바일 viewport **10/10 통과 (~16s)**
- E2E 후 \`select count(*) from page_events where created_at > now() - interval '5 minutes'\` → **0** (webdriver 가드 + .test TLD 가드 동시 동작 확인)

### 수동 (머지 전 권장)
- [ ] \`pnpm dev\` → \`http://localhost:3000?utm_source=test&utm_medium=cpc\` 진입
- [ ] DevTools Network: \`/api/event\` POST 200 OK 1건(page_view) 확인
- [ ] Hero CTA 클릭 → 추가 POST 200 OK 1건(cta_click)
- [ ] Supabase Studio → page_events 테이블에 두 row 생성 + utm_source/medium 채워짐 확인
- [ ] runbook §7 절차 1회 따라가서 빠진 단계가 없는지 검증

## 의존
- 이 PR은 #9(M3) 위에 스택됨. base가 main이라 diff에 M3 변경도 포함되어 보이지만 #9 머지 후 diff는 M4만 남음. **#9 먼저 머지 권장**.

## 후속 이슈 (이 PR 머지 직후 1행씩 생성 예정)
- CI에 E2E 연동 (GH Actions secret + Playwright 캐시)
- OG 이미지를 디자이너 PNG로 교체
- Sentry 도입 검토 (Vercel 로그 1~2주 운영 후 결정)
- 마이그레이션 자동화 (supabase CLI + Actions)

## 참고
- M4 플랜: \`~/.claude/plans/mighty-hopping-swing.md\`
- 마스터 플랜: \`~/.claude/plans/twinkly-discovering-raven.md\` §8(M4)

Closes #5