### PR TITLE
style: 데스크톱에서 좌우 여백을 동적으로 확장

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,12 +6,12 @@ import { SignupForm } from "@/components/sections/SignupForm";
 export default function Home() {
   return (
     <div className="flex justify-center bg-zinc-100 min-h-screen">
-      <main className="relative w-full max-w-[393px] bg-white shadow-2xl min-h-screen flex flex-col overflow-x-hidden">
+      <main className="relative w-full max-w-[393px] sm:max-w-[480px] lg:max-w-[640px] bg-white shadow-2xl min-h-screen flex flex-col overflow-x-hidden">
         <Hero />
         <Target />
         <Features />
         <SignupForm />
-        <footer className="pt-8 pb-16 px-6 border-t border-zinc-100 text-center">
+        <footer className="pt-8 pb-16 px-6 sm:px-14 lg:px-32 border-t border-zinc-100 text-center">
           <p className="text-[11px] text-zinc-300 font-medium">
             © {new Date().getFullYear()} TREND MAP. ALL RIGHTS RESERVED.
           </p>

--- a/apps/web/components/sections/Features.tsx
+++ b/apps/web/components/sections/Features.tsx
@@ -29,7 +29,7 @@ export function Features() {
   return (
     <section
       aria-labelledby="features-title"
-      className="py-20 px-6"
+      className="py-20 px-6 sm:px-14 lg:px-32"
     >
       <header className="mb-16 text-center">
         <p className="text-[11px] font-black uppercase tracking-[0.2em] text-zinc-400 mb-2">

--- a/apps/web/components/sections/Hero.tsx
+++ b/apps/web/components/sections/Hero.tsx
@@ -3,7 +3,7 @@ import { HeroCTA } from "./HeroCTA";
 
 export function Hero() {
   return (
-    <header className="px-6 pt-16 pb-12 text-center">
+    <header className="px-6 sm:px-14 lg:px-32 pt-16 pb-12 text-center">
       <p className="inline-flex items-center gap-1.5 px-3 py-1 mb-6 text-[10px] font-bold tracking-widest uppercase border border-zinc-200 rounded-full text-zinc-400">
         <span
           aria-hidden="true"

--- a/apps/web/components/sections/SignupForm.tsx
+++ b/apps/web/components/sections/SignupForm.tsx
@@ -55,7 +55,7 @@ export function SignupForm() {
     <section
       id="signup"
       aria-labelledby="signup-title"
-      className="py-24 px-6 text-center bg-zinc-900 text-white"
+      className="py-24 px-6 sm:px-14 lg:px-32 text-center bg-zinc-900 text-white"
     >
       <div
         aria-hidden="true"

--- a/apps/web/components/sections/Target.tsx
+++ b/apps/web/components/sections/Target.tsx
@@ -8,7 +8,7 @@ export function Target() {
   return (
     <section
       aria-labelledby="target-title"
-      className="py-16 bg-zinc-50 px-6"
+      className="py-16 bg-zinc-50 px-6 sm:px-14 lg:px-32"
     >
       <div className="mb-10">
         <p className="text-[11px] font-black uppercase tracking-[0.2em] text-zinc-400 mb-2">


### PR DESCRIPTION
## 요약
모바일 393px 컨테이너 그대로면 데스크톱에서 "폰 스크린샷이 zinc-100 위에 동동 떠 있는" 느낌이 강함. 컨테이너 \`max-width\`와 섹션 \`px-6\`을 \`sm\`/\`lg\` 브레이크포인트에서 함께 키워, 카드 자체는 뷰포트에 맞춰 넓어지지만 **콘텐츠 유효 폭은 380~400px로 유지**되도록 함. 모바일 디자인 리듬·텍스트 줄바꿈 그대로.

## 변경
| 위치 | before | after |
|---|---|---|
| 컨테이너 \`max-width\` | \`max-w-[393px]\` | \`max-w-[393px] sm:max-w-[480px] lg:max-w-[640px]\` |
| 섹션 \`px\`(Hero/Target/Features/SignupForm/Footer) | \`px-6\` | \`px-6 sm:px-14 lg:px-32\` |

콘텐츠 유효 폭:
- mobile (≤640px): 393 - 48 = **345px**
- tablet (sm ~640px): 480 - 112 = **368px**
- desktop (lg ≥1024px): 640 - 256 = **384px**

세로 간격, 폰트 크기, 이미지 비율은 손대지 않음 — "좌우 여백만" 명세 준수.

## 검증
- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm --filter @trendmaplp/web test:e2e\` ✅ — chromium + 모바일 viewport 10/10 (~16s)

## 참고
- 모바일 광고 유입이 핵심 타깃이라 모바일 레이아웃은 그대로 유지하는 게 원칙. 본 변경은 데스크톱 미리보기 시 시각적 자연스러움을 보강하는 폴리시.