### PR TITLE
ci: PR마다 Playwright E2E 자동 실행

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,12 @@ on:
     branches: [main]
   pull_request:
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   ci:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
@@ -39,3 +38,64 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: ci
+    concurrency:
+      group: e2e-shared
+      cancel-in-progress: false
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve Playwright version
+        id: pw
+        run: |
+          v=$(pnpm --filter @trendmaplp/web exec playwright --version | awk '{print $2}')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright (browsers + deps)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @trendmaplp/web exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @trendmaplp/web exec playwright install-deps chromium
+
+      - name: Run E2E
+        run: pnpm --filter @trendmaplp/web test:e2e
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: |
+            apps/web/test-results/
+            apps/web/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## 요약
- `.github/workflows/ci.yml`에 `e2e` 잡 신규 추가. 기존 `ci` 잡(typecheck/lint/test/build)이 통과한 뒤에만 실행되어 빠른 실패 + 비용 절감.
- `actions/cache@v4`로 `~/.cache/ms-playwright`를 Playwright 버전별로 캐시. cache hit 시 `playwright install-deps`만, miss 시 `playwright install --with-deps chromium` 실행.
- 저장소 단일 concurrency group(`e2e-shared`, `cancel-in-progress: false`)으로 PR 간 직렬화 → 공유 Supabase에 대한 `e2e+%` 광역 cleanup race 차단.
- 실패 시 `apps/web/test-results/`, `apps/web/playwright-report/`를 artifact로 7일 보존.

## 결정
- **dev 모드 유지**: `pnpm dev`(NODE_ENV=development)에서만 `lib/turnstile.ts`가 secret 없을 때 skip → E2E가 Turnstile 토큰 없이 통과 가능. `pnpm start`(production)는 Turnstile 강제라 부적합.
- **secrets**: 이슈 명시한 `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` + `next build`/dev 시 필요한 `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` 4개 모두 사용.

## 사전 작업 (머지 전 작업자 수동 실행 필요)
저장소 secrets에 4개 키 등록:

```bash
gh secret set SUPABASE_URL                  --body "<from apps/web/.env.local>"
gh secret set SUPABASE_SERVICE_ROLE_KEY     --body "<from apps/web/.env.local>"
gh secret set NEXT_PUBLIC_SUPABASE_URL      --body "<from apps/web/.env.local>"
gh secret set NEXT_PUBLIC_SUPABASE_ANON_KEY --body "<from apps/web/.env.local>"
```

## 테스트 계획
- [ ] secrets 4개 등록 후 PR에 빈 커밋 push → `e2e` 잡 통과 (5 시나리오 × {chromium, mobile} = 10건 PASS)
- [ ] 첫 실행에서 `Install Playwright (browsers + deps)` 분기 사용 확인
- [ ] 두 번째 push에서 `Install Playwright system deps only` 분기 사용 확인 → 캐시 정상
- [ ] 머지 직후 더미 PR 1개 동시 push → `e2e-shared` 그룹 큐잉으로 직렬 실행되는지 확인
- [ ] dev 부팅 시간 로그에서 측정. >100s면 후속 PR에서 `playwright.config.ts`의 `webServer.timeout` 상향
- [ ] 의도적 실패 1회 → `playwright-traces` artifact 업로드/다운로드 검증 (검증 후 원복)

## 범위 외
- WebKit/Firefox 추가 (별도 이슈)
- HTML report 게시 (후속 개선)
- Vercel preview에 대한 E2E (현재는 CI 자체 dev 서버)

Closes #11