### PR TITLE
fix(web): default site URL을 실제 production 도메인으로 교정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
+# --- Site URL (OG/Twitter metadataBase) ---
+# production에서 실제 도메인으로 등록. 미설정 시 layout.tsx의 default 사용.
+NEXT_PUBLIC_SITE_URL=
+
 # --- Cloudflare Turnstile (봇 방어) ---
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,7 +18,7 @@ const SITE_TITLE = "TrendMap — 사전 알림 신청";
 const SITE_DESCRIPTION =
   "인스타·네이버 지도 번갈아 켜지 않아도, 지금 여기 핫한 메뉴와 진짜 후기를 한 번에. 출시 사전 알림을 이메일로 받아보세요.";
 const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://trendmap.vercel.app";
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://trend-map-lp-web.vercel.app";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -38,6 +38,7 @@ Vercel Project → **Settings → Environment Variables**에서 다음 키를 **
 | `SUPABASE_SERVICE_ROLE_KEY` | all | 서버 only (Server Action에서만 사용) |
 | `NEXT_PUBLIC_SUPABASE_URL` | all | 클라이언트 노출 OK |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | all | 클라이언트 노출 OK |
+| `NEXT_PUBLIC_SITE_URL` | all | OG/Twitter metadata base. 커스텀 도메인 이전 시 본 키만 갱신 |
 | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | all | M1에서 발급 |
 | `TURNSTILE_SECRET_KEY` | all | M1, 서버 only |
 | `UPSTASH_REDIS_REST_URL` | all | M1 |


### PR DESCRIPTION
## 배경
`apps/web/app/layout.tsx`의 `SITE_URL` default가 `https://trendmap.vercel.app`로 박혀있었으나, 해당 도메인은 **타사 프로젝트**(HTTP 200, TrendMapLP 콘텐츠 아님). 우리 production은 `https://trend-map-lp-web.vercel.app/`이고, Vercel production env에 `NEXT_PUBLIC_SITE_URL`이 등록되지 않아 default가 그대로 노출.

## 확인된 영향
production HTML(`curl https://trend-map-lp-web.vercel.app/`)에서 다음 메타가 그대로 출력 중:

```html
<meta property="og:image" content="https://trendmap.vercel.app/opengraph-image?...">
<meta name="twitter:image" content="https://trendmap.vercel.app/opengraph-image?...">
```

`metadataBase = new URL(SITE_URL)` 영향으로 모든 상대 메타 URL이 타사 도메인 기반. SNS 공유 시 이미지 깨지거나 타사 콘텐츠가 미리보기에 노출될 위험.

## 변경 사항
- `apps/web/app/layout.tsx:21` — default를 `https://trend-map-lp-web.vercel.app`로 교체.
- `.env.example` — `NEXT_PUBLIC_SITE_URL` 항목 추가 + 주석으로 용도 설명.
- `docs/runbook.md` §3 — env 표에 `NEXT_PUBLIC_SITE_URL` 행 추가. 향후 커스텀 도메인 이전 시 본 키만 갱신.

## 후속 작업
- 머지 후 Vercel 자동 재배포 → `og:image`/`twitter:image`가 우리 도메인으로 정상화되는지 curl로 검증.
- 이슈 #17 본문에 production env 등록 항목으로 `NEXT_PUBLIC_SITE_URL` 추가 (별도 step).

## 테스트 계획
- [ ] CI(typecheck/lint/test/build/e2e) 통과
- [ ] 머지 후 production HTML에서 `og:image`/`twitter:image`가 `https://trend-map-lp-web.vercel.app/opengraph-image?...`로 변경됐는지 curl 확인
- [ ] (선택) Facebook OG 디버거에서 캐시 갱신 후 미리보기 정상 확인

## 범위 외
- `NEXT_PUBLIC_SITE_URL`을 `lib/env.ts`에 등록하는 통일성 작업 — 사용처가 layout.tsx 1곳뿐이라 보류.
- 커스텀 도메인 확보·연결 — 별도 후속 이슈.

Refs #17